### PR TITLE
Compute template path using top-level directory

### DIFF
--- a/src/git-commands.js
+++ b/src/git-commands.js
@@ -120,6 +120,14 @@ function insideWorkTree() {
   return silentRun('git rev-parse --is-inside-work-tree').status === 0;
 }
 
+/**
+ * Computes the path to the top-level directory of the git repository.
+ * @returns {string} Path to the top-level directory of the git repository.
+ */
+function topLevelDirectory() {
+  return silentRun('git rev-parse --show-toplevel').stdout.trim();
+}
+
 module.exports = {
   version: gitVersion,
   config: {
@@ -133,5 +141,6 @@ module.exports = {
   revParse: {
     gitPath,
     insideWorkTree,
+    topLevelDirectory,
   },
 };

--- a/src/git-message/index.js
+++ b/src/git-message/index.js
@@ -76,7 +76,7 @@ function commitTemplatePath() {
   return (
     process.env.GITMOB_MESSAGE_PATH ||
     config.get('commit.template') ||
-    path.relative(process.cwd(), gitMessagePath())
+    path.relative(revParse.topLevelDirectory(), gitMessagePath())
   );
 }
 


### PR DESCRIPTION
Commit 7fa152aab16ef38ac00ec705ae1b71774b23266b introduces a regression that makes it so that if your first `git mob` command is not performed from the top-level directory, then `git commit` fails.

Steps to reproduce

On version 0.5.1

```
mkdir template-path-test
cd template-path-test
git init
mkdir subdir
touch subdir/file.txt
cd subdir
git add .
git mob mark collin
```

Now the commit message template path is incorrectly relative to subdir

```
$ git config commit.template
../.git/.gitmessage
```

So if we commit, it fails.

```
git commit
```

```
fatal: could not read '../.git/.gitmessage': No such file or directory
```