### PR TITLE
Add `mob-print --initials` for coAuthors initials

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ $ git edit-coauthor bb --name="Barry Butterworth"
 $ git edit-coauthor bb --email="barry@butterworth.org"
 ```
 
+Add initials of current mob to `PS1`, in `~/.bashrc`
+```bash
+function git_initials {
+  local initials=$(git mob-print --initials)
+  if [[ -n "${initials}" ]]; then
+    echo " [${initials}]"
+  fi
+}
+
+export PS1="\$(pwd)\$(git_initials) -> "
+```
+
 <sup>\* [If you have git-duet installed, you'll need to uninstall it](https://github.com/findmypast-oss/git-mob/issues/2) since it conflicts with the git-solo command.</sup>
 
 Find out more with `git mob --help`

--- a/src/git-authors/index.js
+++ b/src/git-authors/index.js
@@ -34,6 +34,10 @@ function gitAuthors(readFilePromise, writeFilePromise, overwriteFilePromise) {
     }
   }
 
+  function author({ name, email }) {
+    return `${name} <${email}>`;
+  }
+
   return {
     read: async () => {
       const authorJsonString = await readFile(gitCoauthorsPath);
@@ -68,9 +72,18 @@ function gitAuthors(readFilePromise, writeFilePromise, overwriteFilePromise) {
       const { coauthors } = authorJson;
       return authorInitials.map(initials => {
         missingAuthorError(initials, coauthors);
-        const { name, email } = coauthors[initials];
-        return `${name} <${email}>`;
+        return author(coauthors[initials]);
       });
+    },
+
+    coAuthorsInitials(authorJson, currentCoAuthors) {
+      const { coauthors } = authorJson;
+      return Object.keys(coauthors).reduce((currentCoAuthorsInitials, initials) => {
+        if (currentCoAuthors.includes(author(coauthors[initials]))) {
+          currentCoAuthorsInitials.push(initials);
+        }
+        return currentCoAuthorsInitials;
+      }, []);
     },
 
     toList(authors) {

--- a/src/git-authors/index.spec.js
+++ b/src/git-authors/index.spec.js
@@ -100,3 +100,10 @@ test('Throw error if initials of author are not found', t => {
 
   t.is(error.message, 'Author with initials "hp" not found!');
 });
+
+test('find initials of co-authors', t => {
+  const authors = gitAuthors();
+  const coAuthorsInitials = authors.coAuthorsInitials(authorsJson, ['Jane Doe <jane@findmypast.com>']);
+
+  t.deepEqual(['jd'], coAuthorsInitials);
+});


### PR DESCRIPTION
The main goal of this is to allow for adding a list of initials for the current CoAuthors in your PS1.