### PR TITLE
Suggest coauthors

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ $ git edit-coauthor bb --name="Barry Butterworth"
 $ git edit-coauthor bb --email="barry@butterworth.org"
 ```
 
+### Suggest co-authors base on current repo
+
+Suggest some co-authors to add based on existing committers to your
+current repo
+
+```
+$ git suggest-coauthors
+```
+
 ### Add initials of current mob to your prompt
 
 #### Bash

--- a/bin/suggest-coauthors.js
+++ b/bin/suggest-coauthors.js
@@ -1,0 +1,79 @@
+#! /usr/bin/env node
+const os = require('os');
+const minimist = require('minimist');
+const { runSuggestCoauthorsHelp } = require('../src/helpers');
+const { authors } = require('../src/git-commands');
+
+const argv = minimist(process.argv.slice(2), {
+  alias: {
+    h: 'help',
+  },
+});
+
+async function execute(argv) {
+  if (argv.help) {
+    runSuggestCoauthorsHelp();
+    process.exit(0);
+  }
+
+  await printCoauthorSuggestions();
+  process.exit(0);
+}
+
+async function printCoauthorSuggestions() {
+  try {
+    const shortLogAuthorSummary = authors.shortLogAuthorSummary();
+    const gitAuthors = shortLogAuthorSummary
+      .split(os.EOL)
+      .filter(summary => summary !== '')
+      .map(summary => convertSummaryToCoauthor(summary));
+
+    if (gitAuthors.length > 0) {
+      console.log(os.EOL +
+        'Here are some suggestions for coauthors based on existing authors of this repository' +
+        os.EOL);
+
+      console.log(suggestedCoauthorAddCommands(gitAuthors));
+
+      console.log(os.EOL +
+        'Paste any line above into your console to add them as an author' +
+        os.EOL);
+    } else {
+      console.log('Unable to find existing authors');
+    }
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+function convertSummaryToCoauthor(summaryLine) {
+  const name = nameFromSummaryLine(summaryLine);
+  return {
+    name,
+    email: emailFromSummaryLine(summaryLine),
+    initials: initialsFromName(name)
+  };
+}
+
+function suggestedCoauthorAddCommands(coauthors) {
+  return coauthors
+    .sort()
+    .map(coauthor => ['git add-coauthor', coauthor.initials, JSON.stringify(coauthor.name), coauthor.email].join(' '))
+    .join(os.EOL);
+}
+
+function initialsFromName(name) {
+  return name.split(' ').map(word => word[0].toLowerCase()).join('');
+}
+
+function nameFromSummaryLine(summaryLine) {
+  return summaryLine.split('\t')[1].split(' ').slice(0, -1).join(' ');
+}
+
+function emailFromSummaryLine(summaryLine) {
+  return summaryLine.split('\t')[1].split(' ').pop().slice(1, -1);
+}
+
+execute(argv);
+

--- a/bin/suggest-coauthors.js
+++ b/bin/suggest-coauthors.js
@@ -2,7 +2,7 @@
 const os = require('os');
 const minimist = require('minimist');
 const { runSuggestCoauthorsHelp } = require('../src/helpers');
-const { authors } = require('../src/git-commands');
+const { authors, revParse } = require('../src/git-commands');
 
 const argv = minimist(process.argv.slice(2), {
   alias: {
@@ -14,6 +14,11 @@ async function execute(argv) {
   if (argv.help) {
     runSuggestCoauthorsHelp();
     process.exit(0);
+  }
+
+  if (!revParse.insideWorkTree()) {
+    console.error('Error: not a git repository');
+    process.exit(1);
   }
 
   await printCoauthorSuggestions();

--- a/bin/suggest-coauthors.js
+++ b/bin/suggest-coauthors.js
@@ -29,7 +29,7 @@ async function printCoauthorSuggestions() {
   try {
     const shortLogAuthorSummary = authors.shortLogAuthorSummary();
     const gitAuthors = shortLogAuthorSummary
-      .split(os.EOL)
+      .split('\n')
       .filter(summary => summary !== '')
       .map(summary => convertSummaryToCoauthor(summary));
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "git-solo": "bin/solo.js",
     "git-add-coauthor": "bin/add-coauthor.js",
     "git-delete-coauthor": "bin/delete-coauthor.js",
-    "git-edit-coauthor": "bin/edit-coauthor.js"
+    "git-edit-coauthor": "bin/edit-coauthor.js",
+    "git-suggest-coauthors": "bin/suggest-coauthors.js"
   },
   "repository": {
     "type": "git",

--- a/src/git-commands.js
+++ b/src/git-commands.js
@@ -128,6 +128,15 @@ function topLevelDirectory() {
   return silentRun('git rev-parse --show-toplevel').stdout.trim();
 }
 
+/**
+ * Returns a list of the existing authors for the git repository
+ * including their names and email addresses
+ * @returns {string} of output from git command
+ */
+function shortLogAuthorSummary() {
+  return silentRun('git shortlog --summary --email --number HEAD').stdout.trim();
+}
+
 module.exports = {
   version: gitVersion,
   config: {
@@ -142,5 +151,8 @@ module.exports = {
     gitPath,
     insideWorkTree,
     topLevelDirectory,
+  },
+  authors: {
+    shortLogAuthorSummary,
   },
 };

--- a/src/git-suggest-coauthors.spec.js
+++ b/src/git-suggest-coauthors.spec.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+
+import {
+  exec,
+} from '../test-helpers';
+
+test('suggests potential coauthors', t => {
+  const { stdout } = exec('git suggest-coauthors');
+
+  t.regex(stdout, /Here are some suggestions/);
+  t.regex(stdout, /git add-coauthor rk "Richard Kotze" rkotze@findmypast.com/);
+  t.regex(stdout, /Paste any line above/);
+});
+
+test('-h prints help', t => {
+  const { stdout } = exec('git suggest-coauthors -h');
+
+  t.regex(stdout, /usage/i);
+  t.regex(stdout, /options/i);
+  t.regex(stdout, /example/i);
+});
+

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,6 +14,7 @@ function runHelp() {
       $ git add-coauthor <co-author-initials> "Coauthor Name" <coauthor-email-address>
       $ git delete-coauthor <co-author-initials>
       $ git edit-coauthor <co-author-initials> --name="Coauthor Name" --email="coauthor-email-address"
+      $ git suggest-coauthors
 
     Options
       -h  Prints usage information
@@ -90,6 +91,18 @@ function runMobPrintHelp() {
   console.log(message);
 }
 
+function runSuggestCoauthorsHelp() {
+  const message = stripIndent`
+    Usage
+      $ git suggest-coauthors
+    Options
+      -h  Prints usage information
+    Example
+      $ git suggest-coauthors  # suggests coauthors to add based on existing committers to the repo
+  `;
+  console.log(message);
+}
+
 function runVersion() {
   console.log(pkg.version);
 }
@@ -119,4 +132,5 @@ module.exports = {
   runDeleteCoauthorHelp,
   runEditCoauthorHelp,
   runMobPrintHelp,
+  runSuggestCoauthorsHelp,
 };


### PR DESCRIPTION
Add a suggest-coauthors command

Often the people you will be pairing with have already authored commits on the repo you are working on. This command makes it as easy as possible to add an existing author from the current repo to your list of co-authors.

Example usage

```bash    
$ git suggest-coauthors

Here are some suggestions for co-authors based on existing authors of this repository
    
git add-coauthor aa "Alice Apple" alice@acme.example
git add-coauthor bo "Bob Orange" bob@acme.example
git add-coauthor cb "Charlie Banana" charlie@acme.example

Paste any line above into your console to add them as a co-author
```