### PR TITLE
Don't append co-authors to commit message more than once

### DIFF
--- a/hook-examples/prepare-commit-msg-nodejs
+++ b/hook-examples/prepare-commit-msg-nodejs
@@ -15,6 +15,10 @@ if(/COMMIT_EDITMSG/g.test(commitMessage)){
         // opens .git/COMMIT_EDITMSG
         contents = fs.readFileSync(commitMessage);
 
+        if(contents.indexOf(stdout.trim()) !== -1) {
+            process.exit(0);
+        }
+
         const commentPos = contents.indexOf('# ');
         const gitMessage = contents.slice(0, commentPos);
         const gitComments = contents.slice(commentPos)


### PR DESCRIPTION
I ran into an issue where each time I amend a commit or perform an edit or reword as part of an interactive rebase, my `git mob` coauthors get appended to the commit message again.

I added a check in `prepare-commit-msg` that seems to have fixed this issue for me, so I thought I'd open a PR in case it's of interest.

To replicate the issue:

* `git mob ab cd` (ie. pair with someone)
* make a change and `git commit`
* `git commit --amend --no-edit`

After these steps, for me (using `git mob` in [Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)) the `Co-authored-by:` line appears twice in the commit message. After making the change in this commit to `prepare-commit-msg` this no longer happens: I can amend the commit and `Co-authored-by:` still only appears once.