### PR TITLE
Change source info of bin/mob-print

### DIFF
--- a/bin/mob-print.js
+++ b/bin/mob-print.js
@@ -1,9 +1,10 @@
 #! /usr/bin/env node
+const os = require('os');
 const minimist = require('minimist');
 const { gitAuthors } = require('../src/git-authors');
-const { gitMessage, prepareCommitMsgTemplate } = require('../src/git-message');
 const { config } = require('../src/git-commands');
 const { runMobPrintHelp } = require('../src/helpers');
+const { formatCoAuthorList } = require('../src/git-message');
 
 const argv = minimist(process.argv.slice(2), {
   alias: {
@@ -30,8 +31,8 @@ async function execute(args) {
 
 async function printCoAuthors() {
   try {
-    const coAuthors = await gitMessage(prepareCommitMsgTemplate()).readCoAuthors();
-    console.log(coAuthors);
+    const coAuthors = formatCoAuthorList(config.getAll('git-mob.co-author').split(os.EOL).filter(x => x));
+    console.log(os.EOL + os.EOL + coAuthors);
   } catch (error) {
     console.error(`Error: ${error.message}`);
     process.exit(1);

--- a/src/git-message/index.js
+++ b/src/git-message/index.js
@@ -41,15 +41,19 @@ function read(messagePath) {
   });
 }
 
+function formatCoAuthorList(coAuthorList) {
+  return coAuthorList
+    .map(coAuthor => 'Co-authored-by: ' + coAuthor)
+    .join(os.EOL);
+}
+
 function gitMessage(messagePath, appendFilePromise, readFilePromise) {
   const appendPromise = appendFilePromise || append;
   const readPromise = readFilePromise || read;
 
   return {
     writeCoAuthors: async coAuthorList => {
-      const coAuthorText = coAuthorList
-        .map(coAuthor => 'Co-authored-by: ' + coAuthor)
-        .join(os.EOL);
+      const coAuthorText = formatCoAuthorList(coAuthorList);
 
       await appendPromise(messagePath, os.EOL + os.EOL + coAuthorText);
     },
@@ -85,4 +89,5 @@ module.exports = {
   gitMessagePath,
   commitTemplatePath,
   prepareCommitMsgTemplate,
+  formatCoAuthorList,
 };


### PR DESCRIPTION
This pull request prevents an obtuse error when the user hasn't run `git mob --installTemplate`. It is no longer necessary to run `git mob --installTemplate` before `git mob-print`.

Instead of having `git mob-print` read info from the commit template, it re-computes it from `git config git-mob.co-author`. This way, the user never needs to install a commit template.

Addresses #60